### PR TITLE
Remove mouseover layer references

### DIFF
--- a/behind-reverse-proxy/qa-plugin.php
+++ b/behind-reverse-proxy/qa-plugin.php
@@ -6,9 +6,9 @@
 	http://www.question2answer.org/
 
 	
-	File: qa-plugin/mouseover-layer/qa-plugin.php
+	File: qa-plugin/behind-reverse-proxy/qa-plugin.php
 	Version: See define()s at top of qa-include/qa-base.php
-	Description: Initiates mouseover layer plugin
+	Description: Initiates behind reverse proxy overrides plugin
 
 
 	This program is free software; you can redistribute it and/or


### PR DESCRIPTION
There were some leftover references to the mousover-layer plugin in the `qa-plugin.php` file, which were removed and replaced with text referencing this plugin instead.
